### PR TITLE
Fix Travis build status post organization transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Bio-Formats JACE C++ bindings
 
-[![Build Status](https://travis-ci.org/sbesson/bio-formats-jace.png)](https://travis-ci.org/sbesson/bio-formats-jace)
+[![Build Status](https://travis-ci.org/ome/bio-formats-jace.png)](https://travis-ci.org/ome/bio-formats-jace)


### PR DESCRIPTION
This should fix the broken build status in the repository Readme.
