### PR TITLE
Fix plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,8 +212,8 @@
       <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
     </pluginRepository>
     <pluginRepository>
-      <id>imagej.thirdparty</id>
-      <url>http://maven.imagej.net/content/repositories/thirdparty</url>
+      <id>imagej.releases</id>
+      <url>http://maven.imagej.net/content/repositories/releases</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
While testing 5.2.0-m4, I realized that the `cppwrap-maven-plugin` was not accessible anymore. This simple PR should restore Travis.
