### PR TITLE
Bump Bio-Formats to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
 
    <groupId>ome</groupId>
-   <version>5.2.0-m5</version>
+   <version>5.2.0</version>
   <artifactId>bio-formats-jace</artifactId>
 
   <name>Bio-Formats JACE bindings</name>
@@ -25,22 +25,22 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-bsd</artifactId>
-      <version>5.2.0-m5</version>
+      <version>5.2.0</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-api</artifactId>
-      <version>5.2.0-m5</version>
+      <version>5.2.0</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-common</artifactId>
-      <version>5.2.0-m5</version>
+      <version>5.2.0</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.2.0-m5</version>
+      <version>5.2.0</version>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware.kryo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
 
    <groupId>ome</groupId>
-   <version>5.1.10</version>
+   <version>5.2.0-m5</version>
   <artifactId>bio-formats-jace</artifactId>
 
   <name>Bio-Formats JACE bindings</name>
@@ -25,22 +25,22 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-bsd</artifactId>
-      <version>5.1.10</version>
+      <version>5.2.0-m5</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-api</artifactId>
-      <version>5.1.10</version>
+      <version>5.2.0-m5</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-common</artifactId>
-      <version>5.1.10</version>
+      <version>5.2.0-m5</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.1.10</version>
+      <version>5.2.0-m5</version>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware.kryo</groupId>

--- a/src/main/cppwrap/minimum_writer.cpp
+++ b/src/main/cppwrap/minimum_writer.cpp
@@ -38,9 +38,9 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "formats-api-5.1.10.h"
-#include "formats-bsd-5.1.10.h"
-#include "ome-xml-5.1.10.h"
+#include "formats-api-5.2.0-m5.h"
+#include "formats-bsd-5.2.0-m5.h"
+#include "ome-xml-5.2.0-m5.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Boolean;

--- a/src/main/cppwrap/minimum_writer.cpp
+++ b/src/main/cppwrap/minimum_writer.cpp
@@ -38,9 +38,9 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "formats-api-5.2.0-m5.h"
-#include "formats-bsd-5.2.0-m5.h"
-#include "ome-xml-5.2.0-m5.h"
+#include "formats-api-5.2.0.h"
+#include "formats-bsd-5.2.0.h"
+#include "ome-xml-5.2.0.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Boolean;

--- a/src/main/cppwrap/showinf.cpp
+++ b/src/main/cppwrap/showinf.cpp
@@ -38,9 +38,9 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "formats-api-5.2.0-m5.h"
-#include "formats-bsd-5.2.0-m5.h"
-#include "formats-common-5.2.0-m5.h"
+#include "formats-api-5.2.0.h"
+#include "formats-bsd-5.2.0.h"
+#include "formats-common-5.2.0.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Object;

--- a/src/main/cppwrap/showinf.cpp
+++ b/src/main/cppwrap/showinf.cpp
@@ -38,9 +38,9 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "formats-api-5.1.10.h"
-#include "formats-bsd-5.1.10.h"
-#include "formats-common-5.1.10.h"
+#include "formats-api-5.2.0-m5.h"
+#include "formats-bsd-5.2.0-m5.h"
+#include "formats-common-5.2.0-m5.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Object;


### PR DESCRIPTION
Following the release of 5.2.0, this should bump the Bio-Formats JACE binding to this development line. To test this PR, check Travis is green.
